### PR TITLE
[14.0][FIX] kyc: avoid issues when computing values for users.

### DIFF
--- a/kyc/models/res_partner.py
+++ b/kyc/models/res_partner.py
@@ -71,9 +71,13 @@ class Partner(models.Model):
     )
     kyc_expiration_date = fields.Datetime(compute="_compute_kyc_expiration_date")
     kyc_is_about_expire = fields.Boolean(
-        compute=_compute_kyc_is_about_expire, search=_search_kyc_is_about_expire
+        compute="_compute_kyc_is_about_expire",
+        search="_search_kyc_is_about_expire",
+        compute_sudo=True,
     )
-    kyc_is_about_to_expire_msg = fields.Char(compute="_compute_kyc_is_about_expire")
+    kyc_is_about_to_expire_msg = fields.Char(
+        compute="_compute_kyc_is_about_expire", compute_sudo=True
+    )
     kyc_is_expired = fields.Boolean(
         compute="_compute_kyc_is_expired",
         search="_search_kyc_is_expired",

--- a/kyc/tests/common.py
+++ b/kyc/tests/common.py
@@ -13,6 +13,20 @@ class TestKycCommon(SavepointCase):
         self.webservice_model = self.env["webservice.backend"]
         self.scan_log_model = self.env["kyc.process.log"]
         self.wiz_model = self.env["kyc.partner.scan"]
+        self.user_model = self.env["res.users"]
+
+        self.test_user_1 = self.user_model.create(
+            {
+                "name": "Test user 1",
+                "login": "user1@test.com",
+            }
+        )
+        self.test_user_2 = self.user_model.create(
+            {
+                "name": "Test user 2",
+                "login": "user2@test.com",
+            }
+        )
 
         self.test_contact = self.partner_model.create(
             {

--- a/kyc/tests/test_kyc.py
+++ b/kyc/tests/test_kyc.py
@@ -89,3 +89,21 @@ class TestKyc(TestKycCommon):
         self.assertTrue(self.test_contact.kyc_is_expired)
         search_res = self.partner_model.search([("kyc_is_expired", "=", True)])
         self.assertTrue(self.test_contact in search_res)
+
+    def test_05_read_user_related_partners(self):
+        """Test that users can access partners related to other users."""
+        other_user_partner = self.test_user_2.partner_id
+        self._simulate_scan_partner(partner=other_user_partner)
+        self.assertEqual(
+            other_user_partner.with_user(self.test_user_1).kyc_status, "ok"
+        )
+        self.assertFalse(
+            other_user_partner.with_user(self.test_user_1).kyc_is_about_expire
+        )
+        self.assertFalse(other_user_partner.with_user(self.test_user_1).kyc_is_expired)
+        self.assertTrue(
+            other_user_partner.with_user(self.test_user_1).kyc_expiration_date
+        )
+        self.assertTrue(
+            other_user_partner.with_user(self.test_user_1).kyc_is_about_to_expire_msg
+        )


### PR DESCRIPTION
Partners related to users are not accesible to everyone, users with no rights might have issues accessing the contact screen or the form view of a specific contact.