### PR TITLE
[14.0][FIX] kyc_sanction_scanner: change httpconection to httpsconection

### DIFF
--- a/kyc_sanction_scanner/components/webservice_sanction_scanner.py
+++ b/kyc_sanction_scanner/components/webservice_sanction_scanner.py
@@ -21,7 +21,7 @@ class SanctionScannerApi(Component):
         return res and work.collection.tech_name == "kyc_sanction_scanner"
 
     def _get_connection_and_header(self):
-        conn = http.client.HTTPConnection(self.collection.url)
+        conn = http.client.HTTPSConnection(self.collection.url)
         username = self.collection.username
         password = self.collection.password
         auth_token = base64.b64encode(bytes(username + ":" + password, "utf-8")).decode(


### PR DESCRIPTION
When trying to access the sandbox api, the connection refuses because this service doesn't have this type of connection. The normal api has both connections, so this will fix the problem without affecting the main service.

@ForgeFlow