### PR TITLE
[IMP] kyc: be able to accept transaction by context

### DIFF
--- a/kyc/models/res_partner.py
+++ b/kyc/models/res_partner.py
@@ -144,7 +144,10 @@ class Partner(models.Model):
 
     def _kyc_accept_transaction(self, _record, raise_if_not=True):
         self.ensure_one()
-        accept = not self.kyc_is_expired and self.kyc_status == "ok"
+        # Be able to force the accept status as True by context
+        accept = (
+            not self.kyc_is_expired and self.kyc_status == "ok"
+        ) or self.env.context.get("troy_horse_kyc", False)
         if not accept and raise_if_not:
             raise UserError(
                 _("%s's KYC status ('%s') is not valid or it is expired.")


### PR DESCRIPTION
Allows the user to use the famous Troy Horse to accept the transaction without the need of being accepted.

Can be used by tests that need to override this features.

@ForgeFlow