### PR TITLE
[17.0][FIX] kyc / kyc_sanction_scanner: fix attachments

### DIFF
--- a/kyc/__manifest__.py
+++ b/kyc/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Know Your Customer",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "summary": "Know Your Customer (KYC).",
     "author": "ForgeFlow",
     "website": "https://github.com/ForgeFlow/know-your-customer",

--- a/kyc/migrations/17.0.1.0.1/post-migration.py
+++ b/kyc/migrations/17.0.1.0.1/post-migration.py
@@ -1,0 +1,14 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """
+    Force attachemnts to be related to linked kyc document
+    See https://github.com/odoo/odoo/issues/203580
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    documents = env["kyc.document"].search([])
+    for document in documents:
+        document.attachment_id.write(
+            {"res_id": document.id, "res_model": "kyc.document"}
+        )

--- a/kyc/wizard/kyc_file_upload.py
+++ b/kyc/wizard/kyc_file_upload.py
@@ -35,4 +35,5 @@ class KYCFileUpload(models.TransientModel):
                 "kyc_ubo_id": self.kyc_ubo_id and self.kyc_ubo_id.id or False,
             }
         )
+        attachment.write({"res_id": kyc_doc.id, "res_model": "kyc.document"})
         self.partner_id.kyc_document_ids += kyc_doc

--- a/kyc_sanction_scanner/components/webservice_sanction_scanner.py
+++ b/kyc_sanction_scanner/components/webservice_sanction_scanner.py
@@ -143,6 +143,7 @@ class SanctionScannerApi(Component):
                 "document_type": "scan_certificate",
             }
         )
+        attachment.write({"res_id": kyc_doc.id, "res_model": "kyc.document"})
         partner.kyc_document_ids += kyc_doc
         return True
 


### PR DESCRIPTION
There is a known and reported bug in standard Odoo where the non admin users cannot access to not linked attachments. See https://github.com/odoo/odoo/issues/203580 for more reference. This ensures every attachment created is linked to the kyc document (sharing the access rights).